### PR TITLE
replace compare_and_swap with compare_exchange_weak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.5.1] - 2021-02-27
+
+  * Replace compare_and_swap with compare_exchange_weak.
+    * compare_and_swap has been deprecated as of rust 1.50.0
+
 ## [0.5.0] - 2021-01-30
 
   * Instead of incrementing the worker total and using the returned

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_pool"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["robinfriedli <robinfriedli@icloud.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
 - compare_and_swap has been deprecated as of rust 1.50.0